### PR TITLE
Fix duplicated words in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1228,7 +1228,7 @@ StorageOptions options = StorageOptions.newBuilder().setCredentials(credentials)
 Storage storage = options.getService();
 
 // Call GCS APIs.
-// Since we passed the downscoped credential, we will have have limited readonly access to objects
+// Since we passed the downscoped credential, we will have limited readonly access to objects
 // starting with "customer-a" in bucket "bucket-123".
 storage.get(...)
 ```

--- a/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
@@ -83,8 +83,8 @@ class IamUtils {
    * Returns a signature for the provided bytes.
    *
    * @param serviceAccountEmail the email address for the service account used for signing
-   * @param credentials credentials required for making the IAM call
-   * @param transport transport used for building the HTTP request
+   * @param credentials required for making the IAM call
+   * @param transport used for building the HTTP request
    * @param toSign bytes to sign
    * @param additionalFields additional fields to send in the IAM call
    * @return signed bytes
@@ -195,8 +195,8 @@ class IamUtils {
    * Returns an IdToken issued to the serviceAccount with a specified targetAudience
    *
    * @param serviceAccountEmail the email address for the service account to get an ID Token for
-   * @param credentials credentials required for making the IAM call
-   * @param transport transport used for building the HTTP request
+   * @param credentials required for making the IAM call
+   * @param transport used for building the HTTP request
    * @param targetAudience the audience the issued ID token should include
    * @param additionalFields additional fields to send in the IAM call
    * @param credentialTypeForMetrics credential type for credential making this call

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -75,7 +75,7 @@ public interface IdTokenProvider {
    *
    * @param targetAudience List of audiences the issued ID Token should be valid for. targetAudience
    *     accepts a single string value (multiple audiences are not supported)
-   * @param options List of Credential specific options for for the token. For example, an IDToken
+   * @param options List of Credential specific options for the token. For example, an IDToken
    *     for a ComputeEngineCredential can return platform specific claims if
    *     "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is provided as a list option.
    * @throws IOException if token creation fails

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -75,8 +75,8 @@ public interface IdTokenProvider {
    *
    * @param targetAudience List of audiences the issued ID Token should be valid for. targetAudience
    *     accepts a single string value (multiple audiences are not supported)
-   * @param options List of Credential specific options for the token. For example, an IDToken
-   *     for a ComputeEngineCredential can return platform specific claims if
+   * @param options List of Credential specific options for the token. For example, an IDToken for a
+   *     ComputeEngineCredential can return platform specific claims if
    *     "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is provided as a list option.
    * @throws IOException if token creation fails
    * @return IdToken object which includes the raw id_token, expiration and audience.

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -128,7 +128,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
    *     serviceAccountB must have the Token Creator on serviceAccountC. Finally, C must have Token
    *     Creator on target_principal. If unset, sourceCredential must have that role on
    *     targetPrincipal.
-   * @param scopes scopes to request during the authorization grant
+   * @param scopes to request during the authorization grant
    * @param lifetime number of seconds the delegated credential should be valid. By default this
    *     value should be at most 3600. However, you can follow <a
    *     href='https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-oauth'>these
@@ -167,7 +167,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
    *     serviceAccountB must have the Token Creator on serviceAccountC. Finally, C must have Token
    *     Creator on target_principal. If unset, sourceCredential must have that role on
    *     targetPrincipal.
-   * @param scopes scopes to request during the authorization grant
+   * @param scopes to request during the authorization grant
    * @param lifetime number of seconds the delegated credential should be valid. By default this
    *     value should be at most 3600. However, you can follow <a
    *     href='https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-oauth'>these
@@ -211,7 +211,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
    *     serviceAccountB must have the Token Creator on serviceAccountC. Finally, C must have Token
    *     Creator on target_principal. If unset, sourceCredential must have that role on
    *     targetPrincipal.
-   * @param scopes scopes to request during the authorization grant
+   * @param scopes to request during the authorization grant
    * @param lifetime number of seconds the delegated credential should be valid. By default this
    *     value should be at most 3600. However, you can follow <a
    *     href='https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-oauth'>these
@@ -259,7 +259,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
    *     serviceAccountB must have the Token Creator on serviceAccountC. Finally, C must have Token
    *     Creator on target_principal. If left unset, sourceCredential must have that role on
    *     targetPrincipal.
-   * @param scopes scopes to request during the authorization grant
+   * @param scopes to request during the authorization grant
    * @param lifetime number of seconds the delegated credential should be valid. By default this
    *     value should be at most 3600. However, you can follow <a
    *     href='https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-oauth'>these
@@ -587,7 +587,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
    * Returns an IdToken for the current Credential.
    *
    * @param targetAudience the audience field for the issued ID token
-   * @param options credential specific options for for the token. For example, an ID token for an
+   * @param options credential specific options for the token. For example, an ID token for an
    *     ImpersonatedCredentials can return the email address within the token claims if
    *     "ImpersonatedCredentials.INCLUDE_EMAIL" is provided as a list option.<br>
    *     Only one option value is supported: "ImpersonatedCredentials.INCLUDE_EMAIL" If no options

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -140,7 +140,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
   /**
    * Returns a copy of these credentials with modified claims.
    *
-   * @param newClaims new claims. Any unspecified claim fields default to the the current values.
+   * @param newClaims new claims. Any unspecified claim fields default to the current values.
    * @return new credentials
    */
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -574,8 +574,8 @@ public class OAuth2Credentials extends Credentials {
   /**
    * Result from {@link com.google.auth.oauth2.OAuth2Credentials#getOrCreateRefreshTask()}.
    *
-   * <p>Contains the refresh task and a flag indicating if the task is newly created. If the
-   * task is newly created, it is the caller's responsibility to execute it.
+   * <p>Contains the refresh task and a flag indicating if the task is newly created. If the task is
+   * newly created, it is the caller's responsibility to execute it.
    */
   static class AsyncRefreshResult {
     private final RefreshTask task;

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -234,7 +234,7 @@ public class OAuth2Credentials extends Credentials {
     }
 
     synchronized (lock) {
-      // Immediately resolve the token token if its not expired, or wait for the refresh task to
+      // Immediately resolve the token if it's not expired, or wait for the refresh task to
       // complete
       if (getState() != CacheState.EXPIRED) {
         return Futures.immediateFuture(value);
@@ -574,7 +574,7 @@ public class OAuth2Credentials extends Credentials {
   /**
    * Result from {@link com.google.auth.oauth2.OAuth2Credentials#getOrCreateRefreshTask()}.
    *
-   * <p>Contains the the refresh task and a flag indicating if the task is newly created. If the
+   * <p>Contains the refresh task and a flag indicating if the task is newly created. If the
    * task is newly created, it is the caller's responsibility to execute it.
    */
   static class AsyncRefreshResult {

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -297,7 +297,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   /**
    * Returns a new JwtCredentials instance with modified claims.
    *
-   * @param newClaims new claims. Any unspecified claim fields will default to the the current
+   * @param newClaims new claims. Any unspecified claim fields will default to the current
    *     values.
    * @return new credentials
    */

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -297,8 +297,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   /**
    * Returns a new JwtCredentials instance with modified claims.
    *
-   * @param newClaims new claims. Any unspecified claim fields will default to the current
-   *     values.
+   * @param newClaims new claims. Any unspecified claim fields will default to the current values.
    * @return new credentials
    */
   @Override


### PR DESCRIPTION
## Summary
- remove repeated wording across the codebase
- update IdTokenProvider, OAuth2Credentials, IamUtils, ImpersonatedCredentials
- fix README example comment

## Testing
- `mvn -q test` *(fails: command not found)*